### PR TITLE
fix googleapiclient.errors.UnknownApiNameOrVersion: name: photoslibrary  version: v1

### DIFF
--- a/google_photos_archiver.py
+++ b/google_photos_archiver.py
@@ -29,7 +29,7 @@ def get_service():
         with open('photoslibrary_token.pickle', 'wb') as token:
             pickle.dump(creds, token)
 
-    return build('photoslibrary', 'v1', credentials=creds)
+    return build('photoslibrary', 'v1', credentials=creds, static_discovery=False)
 
 def download_images(media_items, media_num):
     for x in media_items:


### PR DESCRIPTION
I was getting the following error running this on my mac:

```
Getting API Service...
Traceback (most recent call last):
  File "/Users/gligoran/dev/GooglePhotosArchiver/google_photos_archiver.py", line 50, in <module>
    service = get_service()
  File "/Users/gligoran/dev/GooglePhotosArchiver/google_photos_archiver.py", line 32, in get_service
    return build('photoslibrary', 'v1', credentials=creds)
  File "/usr/local/lib/python3.9/site-packages/googleapiclient/_helpers.py", line 134, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/googleapiclient/discovery.py", line 291, in build
    content = _retrieve_discovery_doc(
  File "/usr/local/lib/python3.9/site-packages/googleapiclient/discovery.py", line 405, in _retrieve_discovery_doc
    raise UnknownApiNameOrVersion("name: %s  version: %s" % (serviceName, version))
googleapiclient.errors.UnknownApiNameOrVersion: name: photoslibrary  version: v1
```

This addition fixed it for me.